### PR TITLE
Implements setting Push's User/Live mode

### DIFF
--- a/push.js
+++ b/push.js
@@ -161,6 +161,8 @@ module.exports = {
       onMidiToHardware: listener => { midiOutCallBacks.push(listener); return () => { midiOutCallBacks = midiOutCallBacks.filter(cb => cb !== listener) } },
       timeDivisionButtons: name => roygButtonApi(timeDivisionButtons.filter(button => button.name === name)[0]),
       masterKnob: () => knobApi(masterKnob),
+      setUserMode: () => sendSysex([98,0,1,1]),
+      setLiveMode: () => sendSysex([98,0,1,0]),
       swingKnob: () => knobApi(swingKnob),
       tempoKnob: () => knobApi(tempoKnob),
       touchstrip: () => compose(touchstrip, pressable, releaseable, pitchbendable)


### PR DESCRIPTION
Sysex `[98,0,1,1]` and `[98,0,1,0]` set the Push to User mode and Live mode, respectively. 

Confirmed working on my Push.